### PR TITLE
Return of signature verification is zero for correct verification

### DIFF
--- a/curve.cpp
+++ b/curve.cpp
@@ -35,7 +35,7 @@ void Curve25519::calculateAgreement(const char *myprivate, const char *theirpubl
 
 int Curve25519::verifySignature(const unsigned char *publickey, const unsigned char *message, const unsigned long messagelen, const unsigned char *signature)
 {
-    return curve25519_verify(signature, publickey, message, messagelen);
+    return curve25519_verify(signature, publickey, message, messagelen) == 0;
 }
 
 void Curve25519::calculateSignature(const unsigned char *privatekey, const unsigned char *message, const unsigned long messagelen, const unsigned char *random, unsigned char *signature)

--- a/curve.cpp
+++ b/curve.cpp
@@ -33,7 +33,7 @@ void Curve25519::calculateAgreement(const char *myprivate, const char *theirpubl
     curve25519_donna((uint8_t *)shared_key, (const uint8_t *)myprivate, (const uint8_t *)theirpublic);
 }
 
-int Curve25519::verifySignature(const unsigned char *publickey, const unsigned char *message, const unsigned long messagelen, const unsigned char *signature)
+bool Curve25519::verifySignature(const unsigned char *publickey, const unsigned char *message, const unsigned long messagelen, const unsigned char *signature)
 {
     return curve25519_verify(signature, publickey, message, messagelen) == 0;
 }

--- a/curve.h
+++ b/curve.h
@@ -12,7 +12,7 @@ public:
     static void generatePublicKey(const char *privatekey, char *mypublic);
     static void calculateAgreement(const char *myprivate, const char *theirpublic, char *shared_key);
     static void calculateSignature(const unsigned char *privatekey, const unsigned char *message, const unsigned long messagelen, const unsigned char *random, unsigned char *signature);
-    static int verifySignature(const unsigned char *publickey, const unsigned char *message, const unsigned long messagelen, const unsigned char *signature);
+    static bool verifySignature(const unsigned char *publickey, const unsigned char *message, const unsigned long messagelen, const unsigned char *signature);
 };
 
 #endif  // CURVE_DLL_H


### PR DESCRIPTION
If Curve25519::verifySignature is going to be used as a bool (true for correct verify, false for incorrect), as it's happening in libaxolotl: https://github.com/CODeRUS/libaxolotl/blob/master/ecc/curve.cpp

Then when the result is zero we must return true.
